### PR TITLE
Add open-to-work status pill and intro line

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
         <div class="header-content">
             <h1>Yusuf Dalva</h1>
             <p class="role">Ph.D. Candidate <span class="affil">@ Virginia Tech</span> · Generative AI & Computer Vision</p>
+            <a class="status-pill" href="mailto:ydalva@vt.edu?subject=Full-time%20role%20inquiry">Open to full-time roles <span class="arrow">→</span></a>
             <div class="header-links">
                 <a href="https://scholar.google.com/citations?user=SLtSdMAAAAAJ" target="_blank">
                     <i class="fa-brands fa-google-scholar"></i> Google Scholar
@@ -66,6 +67,7 @@
             <h2><i class="fa-solid fa-user"></i> About</h2>
             <p>I am a Ph.D. candidate (4th year) at Virginia Tech, Blacksburg, where I am affiliated with the <a href="https://sanghani.cs.vt.edu/person/yusuf-dalva/">Sanghani Center for Artificial Intelligence and Data Analytics</a>. I work on making generative models more controllable and customizable to enhance fine-grained control over them. Before joining Virginia Tech, I obtained my M.Sc. & B.Sc. degrees from the Department of Computer Engineering at Bilkent University (<a href="docs/Yusuf_Dalva_Thesis.pdf" target="_blank">M.Sc. Thesis</a>).</p>
             <p>At Virginia Tech, I am working on the controllability of generative models under the supervision of <a href="http://pinguar.org">Pinar Yanardag</a>. In the past, I have been fortunate to work with <a href="http://www.cs.bilkent.edu.tr/~adundar/">Aysegul Dundar</a> at Bilkent University, <a href="https://yijunmaverick.github.io/">Yijun Li</a> at Adobe Research, <a href="https://kfiraberman.github.io/">Kfir Aberman</a> and <a href="https://wangkua1.github.io/">Kuan-Chieh Jackson Wang</a> at Snap Research, and I am currently a Research Intern at Google Research with <a href="https://mdelbra.github.io/">Mauricio Delbracio</a>.</p>
+            <p>I am currently on the job market for <strong>full-time research roles starting in 2027</strong> — please <a href="mailto:ydalva@vt.edu?subject=Full-time%20role%20inquiry">get in touch</a> if you'd like to chat.</p>
             <div class="interest-tags">
                 <span class="tag">controllable generative models</span>
                 <span class="tag">image &amp; video editing</span>

--- a/publications.html
+++ b/publications.html
@@ -39,6 +39,7 @@
         <div class="header-content">
             <h1>Yusuf Dalva</h1>
             <p class="role">Ph.D. Candidate <span class="affil">@ Virginia Tech</span> · Generative AI & Computer Vision</p>
+            <a class="status-pill" href="mailto:ydalva@vt.edu?subject=Full-time%20role%20inquiry">Open to full-time roles <span class="arrow">→</span></a>
             <div class="header-links">
                 <a href="https://scholar.google.com/citations?user=SLtSdMAAAAAJ" target="_blank">
                     <i class="fa-brands fa-google-scholar"></i> Google Scholar

--- a/styles.css
+++ b/styles.css
@@ -367,6 +367,72 @@ section ul li {
 }
 
 /* =========================================================
+   Status pill (open to work)
+   ========================================================= */
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin: 4px 0 14px;
+    padding: 5px 12px 5px 10px;
+    background: rgba(22, 163, 74, 0.10);
+    color: #15803d;
+    border: 1px solid rgba(22, 163, 74, 0.28);
+    border-radius: 999px;
+    font-size: 12.5px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background-color var(--transition), border-color var(--transition), transform var(--transition);
+}
+
+.status-pill:hover {
+    background: rgba(22, 163, 74, 0.16);
+    border-color: rgba(22, 163, 74, 0.5);
+    color: #166534;
+    text-decoration: none;
+    transform: translateY(-1px);
+}
+
+.status-pill::before {
+    content: '';
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #16a34a;
+    box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.55);
+    animation: pulse-dot 2s ease-out infinite;
+}
+
+.status-pill .arrow {
+    margin-left: 2px;
+    opacity: 0.6;
+    transition: transform var(--transition);
+    font-size: 10px;
+}
+
+.status-pill:hover .arrow {
+    transform: translateX(2px);
+    opacity: 1;
+}
+
+[data-theme="dark"] .status-pill {
+    background: rgba(34, 197, 94, 0.14);
+    color: #86efac;
+    border-color: rgba(34, 197, 94, 0.35);
+}
+
+[data-theme="dark"] .status-pill:hover {
+    background: rgba(34, 197, 94, 0.22);
+    color: #bbf7d0;
+    border-color: rgba(34, 197, 94, 0.55);
+}
+
+[data-theme="dark"] .status-pill::before {
+    background: #4ade80;
+    box-shadow: 0 0 0 0 rgba(74, 222, 128, 0.5);
+}
+
+/* =========================================================
    Interest tags
    ========================================================= */
 .interest-tags {


### PR DESCRIPTION
Adds a green pulsing "Open to full-time roles" pill in the hero (both index.html and publications.html), clickable to a prefilled mailto. Also adds a matching sentence at the end of the About section linking the same email, so the signal is visible both at a glance and in context.